### PR TITLE
ng2 + webpack invalid name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ng2 + webpack",
+  "name": "ng2-webpack",
   "version": "0.0.1",
   "description": "ES2015 with Webpack and Decorators",
   "babel": {


### PR DESCRIPTION
ng2 + webpack is an invalid name for npm. Capital letters and spaces are not allows in the "name" field of package.json
