### PR TITLE
Add missing dev dependencies to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
   },
   "devDependencies": {
     "babel-core": "^6.4.5",
+    "babel-loader": "^6.2.5",
+    "babel-plugin-transform-class-properties": "^6.18.0",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-preset-es2015": "^6.3.13",
     "concurrently": "^2.0.0",
     "css-loader": "^0.23.1",


### PR DESCRIPTION
The `watch` script will error out without these dependencies installed.
